### PR TITLE
fix: Make snapshot command run in parallel & only health check once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.2.0]- 2019-06-30
+
+### Fixed
+
+- Take snapshots in parallel
+- Only run healthcheck network check once for performance
+
 ## [0.1.3]- 2019-06-27
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interactor/percy",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Take Percy snapshots with Interactor.js",
   "author": "Wil Wilsman <wil@wilwilsman.com>",
   "license": "MIT",


### PR DESCRIPTION
## What is this?

While adding tests to my weather station project I realized once I added percySnapshots my test times went from just under 1 second to 4.5 seconds.  This happened when the server was not running (and impacted my normal test suite speed)

This was because of the synchronous health check command that is made on each snapshot call. 

This  PR will only make a healthcheck call once and also run all of the snapshot calls in parallel. 

Test speed before this change: `Finished in 4.547 secs / 4.577 secs`
Test speed after this change: `Finished in 1.861 secs / 1.658 secs`

Note: @wwilsman actually wrote this code, I just verified and PR'd 😆 https://gist.github.com/wwilsman/f9ec58dfe14f47bbcf0d58aedf89a221